### PR TITLE
Add description for GPU tutorial of required additional license

### DIFF
--- a/KDB-X/Modules/README.md
+++ b/KDB-X/Modules/README.md
@@ -9,7 +9,7 @@ This repository contains step-by-step tutorials on KDB-X modules.
 
 **AI Libs**: See a variety of AI based KDB-X tutorials for combining structured and unstructured data, vector processing, time series search, and pattern matching.
 
-**GPU**: See a selection of KDB-X GPU Acceleration tutorials for optimizing performance for asof joins and EOD sorting.
+**GPU**: See a selection of KDB-X GPU Acceleration tutorials for optimizing performance for asof joins and EOD sorting. [**Note: this requires an additional GPU license - please email devrel@kx.com for an evaluation request if you don't already own one**]
 
 **kurl_REST**: Learn to use the kurl and REST modules by building a custom market data API with KURL and REST in KDB-X.
 

--- a/KDB-X/Modules/gpu/README.md
+++ b/KDB-X/Modules/gpu/README.md
@@ -1,6 +1,9 @@
 # 🚀 KDB-X GPU Acceleration Tutorials
 
 GPU Acceleration is a new offering of KDB-X that ships the `gpu` module as a first-class, production-ready capability.
+
+**Note: this requires an additional GPU license - please email devrel@kx.com for an evaluation request if you don't already own one**
+
 This folder contains concise, step-by-step tutorials designed to help developers optimize performance that otherwise can be the source of CPU bottlenecks, accelerating various table and analytical operations.
 
 The [GPU module](https://code.kx.com/kdb-x/modules/gpu/introduction.html) provides a number of APIs allowing users to build KDB-X workloads which can leverage GPU computing for specific operations:


### PR DESCRIPTION
We want to surface the fact that the GPU module and tutorial requires an additional GPU license, as it will otherwise not work - this is not currently shown to a user except for the GPU Module docs